### PR TITLE
Don't do anything if userId is null

### DIFF
--- a/bot-moe/src/main/java/fr/tavernedudev/bot/moe/slack/SlackBot.java
+++ b/bot-moe/src/main/java/fr/tavernedudev/bot/moe/slack/SlackBot.java
@@ -112,7 +112,7 @@ public class SlackBot extends Bot {
     }
 
     private boolean shouldDoSomething(@Nullable Event event) {
-        return event != null && !isBot(event.getUserId()) && isALinkOnlyChannel(event.getChannelId()) && !isLastPostInChannelASubtopicMessage(event.getChannelId());
+        return event != null && event.getUserId()!=null && !isBot(event.getUserId()) && isALinkOnlyChannel(event.getChannelId()) && !isLastPostInChannelASubtopicMessage(event.getChannelId());
     }
 
     @VisibleForTesting
@@ -120,7 +120,8 @@ public class SlackBot extends Bot {
         return userId != null && userId.equals(getBotUserId());
     }
 
-    private boolean isALinkOnlyChannel(@Nullable String channelId){
+    @VisibleForTesting
+    boolean isALinkOnlyChannel(@Nullable String channelId){
         if(StringUtils.isBlank(channelId)){
             return false;
         }

--- a/bot-moe/src/test/java/fr/tavernedudev/bot/moe/slack/SlackBotTest.java
+++ b/bot-moe/src/test/java/fr/tavernedudev/bot/moe/slack/SlackBotTest.java
@@ -25,20 +25,6 @@ public class SlackBotTest {
     }
 
     @Test
-    public void isBotShouldNotThrowAnyExceptionWhenNullParameterIsGiven() throws Exception {
-
-        // Given
-        String nullParameter = null;
-
-        // When
-        slackbot.isBot(nullParameter);
-
-        // Then
-        // no exception should occurs
-
-    }
-
-    @Test
     public void isBotShouldReturnFalseWhenNullParameterIsGiven() throws Exception {
 
         // Given
@@ -82,5 +68,21 @@ public class SlackBotTest {
         assertFalse(actualResponse);
 
     }
+
+    @Test
+    public void isALinkChannelShouldReturnFalseWhenNullIsGiven() throws Exception {
+
+        // Given
+        String nullChannelId = null;
+
+        // When
+        boolean actualResponse = slackbot.isALinkOnlyChannel(nullChannelId);
+
+        // Then
+        assertFalse(actualResponse);
+
+    }
+
+
 
 }


### PR DESCRIPTION
Sometime the slack api provide a null event.getUserId() which means basically we cannot do anything -> simply do nothing when this occurs